### PR TITLE
Merge Scheme v0.0.3-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "seax"
 version = "0.0.2"
 dependencies = [
  "docopt 0.6.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "seax_scheme 0.0.3",
  "seax_svm 0.2.0-rc.2",
@@ -14,7 +14,7 @@ name = "docopt"
 version = "0.6.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -25,7 +25,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ version = "~0.2.0"
 
 [dependencies.seax_scheme]
 path = "seax_scheme"
+version = "~0.0.3"

--- a/seax_scheme/src/ast/mod.rs
+++ b/seax_scheme/src/ast/mod.rs
@@ -15,23 +15,30 @@ mod tests;
 /// `ForkTable` mapping `&str` (names) to `(uint,uint)` tuples,
 /// representing the location in the `$e` stack storing the value
 /// bound to that name.
+
+#[stable(feature = "forktable", since = "0.0.3")]
 pub type SymTable<'a>   = ForkTable<'a, &'a str, (usize,usize)>;
-/// A `CompileResult` is either `Ok(SVMCell)` or `Err(&str)`.
+/// A `CompileResult` is either `Ok(SVMCell)` or `Err(&str)`
+#[stable(feature = "compile", since = "0.0.3")]
 pub type CompileResult  = Result<Vec<SVMCell>, String>;
 
 static INDENT: &'static str = "\t";
 
 /// Trait for AST nodes.
+#[stable(feature = "ast", since = "0.0.2")]
 pub trait ASTNode {
     /// Compile this node to a list of SVM expressions
+    #[unstable(feature="compile")]
     fn compile<'a>(&'a self,
                    state: &'a SymTable<'a>
                    )                    -> CompileResult;
 
     /// Pretty-print this node
+    #[stable(feature = "ast", since = "0.0.2")]
     fn prettyprint(&self)               -> String { self.print_level(0usize) }
 
     /// Pretty-print this node at the desired indent level
+    #[stable(feature = "ast", since = "0.0.2")]
     fn print_level(&self, level: usize) -> String;
 }
 
@@ -53,18 +60,29 @@ pub trait ASTNode {
 ///  TODO: macros should happen
 ///  TODO: figure out quasiquote somehow.
 #[derive(Clone, PartialEq,Debug)]
+#[stable(feature = "ast", since = "0.0.2")]
 pub enum ExprNode {
+    #[stable(feature = "ast", since = "0.0.2")]
     Root(RootNode),
+    #[stable(feature = "ast", since = "0.0.2")]
     SExpr(SExprNode),
+    #[stable(feature = "ast", since = "0.0.2")]
     Name(NameNode),
+    #[stable(feature = "ast", since = "0.0.2")]
     ListConst(ListNode),
+    #[stable(feature = "ast", since = "0.0.2")]
     NumConst(NumNode),
+    #[stable(feature = "ast", since = "0.0.2")]
     BoolConst(BoolNode),
+    #[stable(feature = "ast", since = "0.0.2")]
     StringConst(StringNode),
+    #[stable(feature = "ast", since = "0.0.2")]
     CharConst(CharNode),
 }
 
 impl ASTNode for ExprNode {
+
+    #[stable(feature = "compile", since = "0.0.3")]
     fn compile<'a>(&'a self, state: &'a SymTable<'a>) -> CompileResult {
         match *self {
             //  TODO: should some of these nodes cause a state fork?
@@ -79,6 +97,7 @@ impl ASTNode for ExprNode {
         }
     }
 
+    #[stable(feature = "ast", since = "0.0.2")]
     fn print_level(&self, level: usize) -> String {
         match *self {
             Root(ref node)          => node.print_level(level),
@@ -95,20 +114,28 @@ impl ASTNode for ExprNode {
 
 
 #[derive(Clone, PartialEq,Debug)]
+#[stable(feature = "ast", since = "0.0.2")]
 pub enum NumNode {
+    #[stable(feature = "ast", since = "0.0.2")]
     IntConst(IntNode),
+    #[stable(feature = "ast", since = "0.0.2")]
     UIntConst(UIntNode),
+    #[stable(feature = "ast", since = "0.0.2")]
     FloatConst(FloatNode)
 }
 
 /// AST node for the root of a program's AST
 #[derive(Clone, PartialEq,Debug)]
+#[stable(feature = "ast", since = "0.0.2")]
 pub struct RootNode { pub exprs: Vec<ExprNode> }
 
 impl ASTNode for RootNode {
+    #[unstable(feature="compile")]
     fn compile<'a>(&'a self, state: &'a SymTable<'a>) -> CompileResult {
         Err("UNINPLEMENTED".to_string())
     }
+
+    #[stable(feature = "ast", since = "0.0.2")]
     fn print_level(&self, level: usize) -> String {
         self.exprs
             .iter()
@@ -127,13 +154,16 @@ impl ASTNode for RootNode {
 /// This includes function application, assignment,
 /// function definition, et cetera...Scheme is not a complexl anguage.
 #[derive(Clone, PartialEq,Debug)]
+#[stable(feature = "ast", since = "0.0.2")]
 pub struct SExprNode {
+    #[stable(feature = "ast", since = "0.0.2")]
     pub operator: NameNode,
+    #[stable(feature = "ast", since = "0.0.2")]
     pub operands: Vec<ExprNode>,
 }
 
 impl ASTNode for SExprNode {
-
+    #[unstable(feature="compile")]
     fn compile<'a>(&'a self, state: &'a SymTable<'a>) -> CompileResult {
         match self.operator {
             ref op if op.is_arith() || op.is_cmp() => {
@@ -187,6 +217,7 @@ impl ASTNode for SExprNode {
         }*/
     }
 
+    #[stable(feature = "ast", since = "0.0.2")]
     fn print_level(&self, level: usize) -> String {
         let mut tab = String::new();
         for _ in 0 .. level { tab.push_str(INDENT); };
@@ -214,12 +245,16 @@ impl ASTNode for SExprNode {
 
 /// AST node for a list literal
 #[derive(Clone, PartialEq,Debug)]
+#[stable(feature = "ast", since = "0.0.2")]
 pub struct ListNode { pub elements: Vec<ExprNode> }
 
 impl ASTNode for ListNode {
+    #[unstable(feature="compile")]
     fn compile<'a>(&'a self, state: &SymTable<'a>) -> CompileResult {
         Err("UNINPLEMENTED".to_string())
     }
+
+    #[stable(feature = "ast", since = "0.0.2")]
     fn print_level(&self, level: usize) -> String {
         let mut tab = String::new();
         for _ in 0 .. level {tab.push_str(INDENT); };
@@ -240,10 +275,12 @@ impl ASTNode for ListNode {
 
 /// AST node for an identifier
 #[derive(Clone, PartialEq,Debug)]
+#[stable(feature = "ast", since = "0.0.2")]
 pub struct NameNode { pub name: String }
 
 impl NameNode {
     /// Returns true if this is a keyword
+    #[stable(feature = "ast", since = "0.0.3")]
     fn is_kw(&self) -> bool {
         match self.name.as_ref() {
             "access" | "define-syntax" | "macro"  | "and"  | "delay"
@@ -258,6 +295,7 @@ impl NameNode {
         }
     }
     /// Returns true if this is an arithmetic operator
+    #[stable(feature = "ast", since = "0.0.3")]
     fn is_arith(&self) -> bool {
       match self.name.as_ref() {
          "+" | "-" | "*" | "/" | "%" => true,
@@ -265,6 +303,7 @@ impl NameNode {
       }
    }
     /// Returns true if this is a comparison operator
+    #[stable(feature = "ast", since = "0.0.3")]
     fn is_cmp(&self) -> bool {
       match self.name.as_ref() {
          "=" | "!=" | ">" | "<" | ">=" | "<=" => true,
@@ -274,9 +313,12 @@ impl NameNode {
 }
 
 impl ASTNode for NameNode {
+    #[unstable(feature="compile")]
     fn compile<'a>(&'a self, state: &'a SymTable<'a>) -> CompileResult {
         Err("UNINPLEMENTED".to_string())
     }
+
+    #[stable(feature = "ast", since = "0.0.2")]
     fn print_level(&self, level: usize) -> String {
         let mut tab = String::new();
         for _ in 0 .. level {tab.push_str(INDENT)};
@@ -294,9 +336,14 @@ impl ASTNode for NameNode {
 
 /// AST node for an integer constant
 #[derive(Clone, PartialEq,Debug)]
-pub struct IntNode { pub value: isize }
+#[stable(feature = "ast", since = "0.0.2")]
+pub struct IntNode {
+    #[stable(feature = "ast", since = "0.0.2")]
+    pub value: isize
+}
 
 impl ASTNode for NumNode {
+    #[stable(feature="compile",since="0.0.3")]
     fn compile<'a>(&'a self, state: &'a SymTable<'a>) -> CompileResult {
        match *self {
             NumNode::UIntConst(ref node)    => Ok(
@@ -310,6 +357,8 @@ impl ASTNode for NumNode {
                 )
        }
     }
+
+    #[stable(feature = "ast", since = "0.0.2")]
     fn print_level(&self, level: usize) -> String {
         let mut tab = String::new();
         for _ in 0 .. level {tab.push_str(INDENT);};
@@ -339,22 +388,35 @@ impl ASTNode for NumNode {
 
 /// AST node for an unsigned integer constant
 #[derive(Clone, PartialEq,Debug)]
-pub struct UIntNode { pub value: usize }
+#[stable(feature = "ast", since = "0.0.2")]
+pub struct UIntNode {
+    #[stable(feature = "ast", since = "0.0.2")]
+    pub value: usize
+}
 
 /// AST node for a floating-point constant
 #[derive(Clone, PartialEq,Debug)]
-pub struct FloatNode { pub value: f64 }
+#[stable(feature = "ast", since = "0.0.2")]
+pub struct FloatNode {
+    #[stable(feature = "ast", since = "0.0.2")]
+    pub value: f64
+}
 
 /// AST node for a boolean constant
 #[derive(Clone, PartialEq,Debug)]
-pub struct BoolNode { pub value: bool }
+#[stable(feature = "ast", since = "0.0.2")]
+pub struct BoolNode {
+    #[stable(feature = "ast", since = "0.0.2")]
+    pub value: bool
+}
 
 impl ASTNode for BoolNode {
-
+    #[unstable(feature="compile")]
     fn compile<'a>(&'a self,state:  &'a SymTable)    -> CompileResult {
         Err("UNINPLEMENTED".to_string())
     }
 
+    #[stable(feature = "ast", since = "0.0.2")]
     fn print_level(&self, level: usize) -> String {
         let mut tab = String::new();
         for _ in 0 .. level {tab.push_str(INDENT);};
@@ -372,12 +434,18 @@ impl ASTNode for BoolNode {
 
 /// AST node for a character constant
 #[derive(Clone, PartialEq,Debug)]
-pub struct CharNode { pub value: char }
+#[stable(feature = "ast", since = "0.0.2")]
+pub struct CharNode {
+    #[stable(feature = "ast", since = "0.0.2")]
+    pub value: char
+}
 
 impl ASTNode for CharNode {
+    #[unstable(feature="compile")]
     fn compile<'a>(&'a self, state: &'a SymTable<'a>) -> CompileResult {
         Err("UNINPLEMENTED".to_string())
     }
+    #[stable(feature = "ast", since = "0.0.2")]
     fn print_level(&self, level: usize) -> String {
         let mut tab = String::new();
         for _ in 0 .. level {tab.push_str(INDENT);};
@@ -394,12 +462,15 @@ impl ASTNode for CharNode {
 
 /// AST node for a  string constant
 #[derive(Clone, PartialEq,Debug)]
+#[stable(feature = "ast", since = "0.0.2")]
 pub struct StringNode { pub value: String }
 
 impl ASTNode for StringNode {
+    #[unstable(feature="compile")]
     fn compile<'a>(&'a self, state: &'a SymTable<'a>) -> CompileResult {
         Err("UNINPLEMENTED".to_string())
     }
+    #[stable(feature = "ast", since = "0.0.2")]
     fn print_level(&self, level: usize) -> String {
         let mut tab = String::new();
         for _ in 0 .. level {tab.push_str(INDENT);};

--- a/seax_scheme/src/ast/mod.rs
+++ b/seax_scheme/src/ast/mod.rs
@@ -17,7 +17,7 @@ mod tests;
 /// bound to that name.
 pub type SymTable<'a>   = ForkTable<'a, &'a str, (usize,usize)>;
 /// A `CompileResult` is either `Ok(SVMCell)` or `Err(&str)`.
-pub type CompileResult  = Result<Vec<SVMCell>, &'static str>;
+pub type CompileResult  = Result<Vec<SVMCell>, String>;
 
 static INDENT: &'static str = "\t";
 
@@ -107,7 +107,7 @@ pub struct RootNode { pub exprs: Vec<ExprNode> }
 
 impl ASTNode for RootNode {
     fn compile<'a>(&'a self, state: &'a SymTable<'a>) -> CompileResult {
-        Err("UNINPLEMENTED")
+        Err("UNINPLEMENTED".to_string())
     }
     fn print_level(&self, level: usize) -> String {
         self.exprs
@@ -176,7 +176,7 @@ impl ASTNode for SExprNode {
                         )),
                     InstCell(LDF)
                     )),
-                None         => Err("[error] Unknown identifier!")
+                None         => Err(format!("[error] Unknown identifier `{}`", op.name))
             }
         }
         /*let ref token = self.operator.name;
@@ -218,7 +218,7 @@ pub struct ListNode { pub elements: Vec<ExprNode> }
 
 impl ASTNode for ListNode {
     fn compile<'a>(&'a self, state: &SymTable<'a>) -> CompileResult {
-        Err("UNINPLEMENTED")
+        Err("UNINPLEMENTED".to_string())
     }
     fn print_level(&self, level: usize) -> String {
         let mut tab = String::new();
@@ -275,7 +275,7 @@ impl NameNode {
 
 impl ASTNode for NameNode {
     fn compile<'a>(&'a self, state: &'a SymTable<'a>) -> CompileResult {
-        Err("UNINPLEMENTED")
+        Err("UNINPLEMENTED".to_string())
     }
     fn print_level(&self, level: usize) -> String {
         let mut tab = String::new();
@@ -352,7 +352,7 @@ pub struct BoolNode { pub value: bool }
 impl ASTNode for BoolNode {
 
     fn compile<'a>(&'a self,state:  &'a SymTable)    -> CompileResult {
-        Err("UNINPLEMENTED")
+        Err("UNINPLEMENTED".to_string())
     }
 
     fn print_level(&self, level: usize) -> String {
@@ -376,7 +376,7 @@ pub struct CharNode { pub value: char }
 
 impl ASTNode for CharNode {
     fn compile<'a>(&'a self, state: &'a SymTable<'a>) -> CompileResult {
-        Err("UNINPLEMENTED")
+        Err("UNINPLEMENTED".to_string())
     }
     fn print_level(&self, level: usize) -> String {
         let mut tab = String::new();
@@ -398,7 +398,7 @@ pub struct StringNode { pub value: String }
 
 impl ASTNode for StringNode {
     fn compile<'a>(&'a self, state: &'a SymTable<'a>) -> CompileResult {
-        Err("UNINPLEMENTED")
+        Err("UNINPLEMENTED".to_string())
     }
     fn print_level(&self, level: usize) -> String {
         let mut tab = String::new();

--- a/seax_scheme/src/ast/tests.rs
+++ b/seax_scheme/src/ast/tests.rs
@@ -97,3 +97,73 @@ fn test_compile_mul() {
         ])
     )
 }
+
+#[test]
+fn test_compile_nested_sexpr() {
+    let ast = SExprNode {
+        operator: NameNode { name: "+".to_string() },
+        operands: vec![
+            NumConst(IntConst(IntNode{ value: 4isize })),
+            SExpr(SExprNode {
+                operator: NameNode { name: "-".to_string() },
+                operands: vec![
+                    NumConst(IntConst(IntNode{ value: 1isize })),
+                    NumConst(IntConst(IntNode{ value: 2isize })),
+                    NumConst(IntConst(IntNode{ value: 3isize }))
+                ]
+            })
+        ]
+    };
+    assert_eq!(
+        ast.compile(&SymTable::new()),
+        Ok(vec![
+            InstCell(LDC), AtomCell(SInt(3)),
+            InstCell(LDC), AtomCell(SInt(2)),
+            InstCell(SUB),
+            InstCell(LDC), AtomCell(SInt(1)),
+            InstCell(SUB),
+            InstCell(LDC), AtomCell(SInt(4)),
+            InstCell(ADD)
+        ])
+    )
+}
+
+#[test]
+fn test_compile_gte() {
+    let ast = SExprNode {
+        operator: NameNode { name: ">=".to_string() },
+        operands: vec![
+            NumConst(FloatConst(FloatNode{ value: 1f64 })),
+            NumConst(IntConst(IntNode{ value: 2isize })),
+        ]
+    };
+    assert_eq!(
+        ast.compile(&SymTable::new()),
+        Ok(vec![
+            InstCell(LDC), AtomCell(SInt(2isize)),
+            InstCell(LDC), AtomCell(Float(1f64)),
+            InstCell(GTE)
+        ])
+    )
+}
+
+#[test]
+fn test_compile_lte() {
+    let ast = SExprNode {
+        operator: NameNode { name: "<=".to_string() },
+        operands: vec![
+            NumConst(UIntConst(UIntNode{ value: 3usize })),
+            NumConst(IntConst(IntNode{ value: 2isize })),
+        ]
+    };
+    assert_eq!(
+        ast.compile(&SymTable::new()),
+        Ok(vec![
+            InstCell(LDC), AtomCell(SInt(2isize)),
+            InstCell(LDC), AtomCell(UInt(3usize)),
+            InstCell(LTE)
+        ])
+    )
+}
+
+

--- a/seax_scheme/src/forktab.rs
+++ b/seax_scheme/src/forktab.rs
@@ -18,7 +18,7 @@ use std::hash::Hash;
 /// reference implementation written by Hawk Weisman for the Decaf
 /// compiler, which is available [here](https://github.com/hawkw/decaf/blob/master/src/main/scala/com/meteorcode/common/ForkTable.scala).
 #[derive(Debug)]
-#[unstable(feature = "forktable", since = "0.0.3")]
+#[unstable(feature = "forktable")]
 pub struct ForkTable<'a, K:'a +  Eq + Hash,V: 'a>  {
     table: HashMap<K, V>,
     whiteouts: HashSet<K>,
@@ -119,7 +119,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     ///       level, to remove the need to keep a mutable borrow
     ///       on the parent level. We could allow an overwrite here
     ///       instead.
-   #[unstable(feature = "forktable", since = "0.0.3")]
+   #[unstable(feature = "forktable")]
    pub fn get_mut<'b>(&'b mut self, key: &K) -> Option<&'b mut V> {
         if self.whiteouts.contains(key) {
             None
@@ -178,7 +178,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     /// assert_eq!(level_2.chain_contains_key(&1isize), false);
     /// ```
     ///
-    #[unstable(feature = "forktable", since = "0.0.3")]
+    #[unstable(feature = "forktable")]
     pub fn remove(&mut self, key: &K) -> Option<V> where K: Clone {
             if self.table.contains_key(key) {
                 self.table.remove(key)
@@ -333,7 +333,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     /// parent `ForkTable`.
     ///
     /// TODO: should whiteouts be carried over? look into this.
-    #[unstable(feature = "forktable", since = "0.0.3")]
+    #[unstable(feature = "forktable")]
     pub fn fork(&'a mut self) -> ForkTable<'a, K,V> {
         ForkTable {
             table: HashMap::new(),
@@ -343,7 +343,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     }
 
     /// Constructs a new `ForkTable<K,V>`
-    #[stable(feature = "forktable", since = "0.0.3")]
+    #[stable(feature = "forktable",since="0.0.3")]
     pub fn new() -> ForkTable<'a, K,V> {
         ForkTable {
             table: HashMap::new(),

--- a/seax_scheme/src/forktab.rs
+++ b/seax_scheme/src/forktab.rs
@@ -49,6 +49,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     /// # Examples
     ///
     /// ```
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
     /// assert_eq!(table.get(&1isize), None);
@@ -57,6 +58,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     /// assert_eq!(table.get(&2isize), None);
     /// ```
     /// ```
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut level_1: ForkTable<isize,&str> = ForkTable::new();
     /// level_1.insert(1isize, "One");
@@ -100,6 +102,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     /// # Examples
     ///
     /// ```
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
     /// assert_eq!(table.get_mut(&1isize), None);
@@ -108,6 +111,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     /// assert_eq!(table.get_mut(&2isize), None);
     /// ```
     /// ```
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut level_1: ForkTable<isize,&str> = ForkTable::new();
     /// level_1.insert(1isize, "One");
@@ -159,6 +163,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     ///
     /// # Examples
     /// ```
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
     /// table.insert(1isize, "One");
@@ -167,6 +172,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     /// assert_eq!(table.contains_key(&1isize), false);
     /// ```
     /// ```
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut level_1: ForkTable<isize,&str> = ForkTable::new();
     /// level_1.insert(1isize, "One");
@@ -214,6 +220,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     /// Simply inserting an entry:
     ///
     /// ```
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
     /// assert_eq!(table.get(&1isize), None);
@@ -224,6 +231,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     /// Overwriting the value associated with a key:
     ///
     /// ```ignore
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
     /// assert_eq!(table.get(&1isize), None);
@@ -256,6 +264,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     ///
     /// # Examples
     /// ```
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
     /// assert_eq!(table.contains_key(&1isize), false);
@@ -263,6 +272,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     /// assert_eq!(table.contains_key(&1isize), true);
     /// ```
     /// ```ignore
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut level_1: ForkTable<isize,&str> = ForkTable::new();
     /// assert_eq!(level_1.contains_key(&1isize), false);
@@ -296,6 +306,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     ///
     /// # Examples
     /// ```
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
     /// assert_eq!(table.chain_contains_key(&1isize), false);
@@ -303,6 +314,7 @@ impl<'a, K,V> ForkTable<'a, K, V> where K: Eq + Hash {
     /// assert_eq!(table.chain_contains_key(&1isize), true);
     /// ```
     /// ```ignore
+    /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut level_1: ForkTable<isize,&str> = ForkTable::new();
     /// assert_eq!(level_1.chain_contains_key(&1isize), false);

--- a/seax_scheme/src/lib.rs
+++ b/seax_scheme/src/lib.rs
@@ -1,4 +1,5 @@
 #![crate_name = "seax_scheme"]
+#![unstable(feature="scheme")]
 #![crate_type = "lib"]
 #![feature(convert)]
 #![feature(box_syntax,box_patterns)]
@@ -44,6 +45,7 @@ pub mod parser;
 
 mod forktab;
 
+#[unstable(feature="forktable")]
 pub use self::forktab::ForkTable;
 
 use svm::slist::{List,Stack};

--- a/seax_scheme/src/lib.rs
+++ b/seax_scheme/src/lib.rs
@@ -1,6 +1,10 @@
 #![crate_name = "seax_scheme"]
 #![crate_type = "lib"]
-#![feature(convert,core,box_syntax,box_patterns,slice_patterns,collections,staged_api)]
+#![feature(convert)]
+#![feature(box_syntax,box_patterns)]
+#![feature(slice_patterns)]
+#![feature(collections)]
+#![feature(staged_api)]
 #![staged_api]
 
 //! Library for compiling Scheme programs to Seax SVM bytecode.

--- a/seax_scheme/src/lib.rs
+++ b/seax_scheme/src/lib.rs
@@ -1,6 +1,7 @@
 #![crate_name = "seax_scheme"]
 #![crate_type = "lib"]
-#![feature(convert,core,box_syntax,box_patterns,slice_patterns,collections)]
+#![feature(convert,core,box_syntax,box_patterns,slice_patterns,collections,staged_api)]
+#![staged_api]
 
 //! Library for compiling Scheme programs to Seax SVM bytecode.
 //!
@@ -23,6 +24,7 @@ extern crate seax_svm as svm;
 /// program, and is responsible for compiling those programs
 /// to SVM bytecode instructions, performing semantic analysis
 /// (as necessary), and (eventually) for optimizing programs.
+#[unstable(feature = "ast")]
 pub mod ast;
 
 /// Contains the Scheme parser.
@@ -33,6 +35,7 @@ pub mod ast;
 /// Any deviations from the R6RS standard, especially those with an impact
 /// on the valid programs accepted by the parser, will be noted in the
 /// parser's RustDoc.
+#[unstable(feature="parser")]
 pub mod parser;
 
 mod forktab;
@@ -46,6 +49,7 @@ use self::ast::{ASTNode,ExprNode};
 
 
 /// Compile a Scheme program into a list of SVM cells (a control stack)
+#[unstable(feature="compile")]
 pub fn compile(program: &str) -> Result<List<SVMCell>, String> {
     parser::parse(program)
         .and_then(|tree: ExprNode      | tree.compile(&ForkTable::new()) )

--- a/seax_scheme/src/lib.rs
+++ b/seax_scheme/src/lib.rs
@@ -39,3 +39,17 @@ mod forktab;
 
 pub use self::forktab::ForkTable;
 
+use svm::slist::{List,Stack};
+use svm::cell::SVMCell;
+
+use self::ast::{ASTNode,ExprNode};
+
+
+/// Compile a Scheme program into a list of SVM cells (a control stack)
+pub fn compile(program: &str) -> Result<List<SVMCell>, String> {
+    parser::parse(program)
+        .and_then(|tree: ExprNode      | tree.compile(&ForkTable::new()) )
+        .map(     |insts: Vec<SVMCell> | insts.into_iter().rev().fold(List::new(),
+                  |st: List<SVMCell>, i| st.push(i)
+            ))
+}

--- a/seax_scheme/src/parser/mod.rs
+++ b/seax_scheme/src/parser/mod.rs
@@ -9,6 +9,7 @@ use super::ast::ExprNode::*;
 use std::str::FromStr;
 use std::num::FromStrRadix;
 use std::char;
+use std::error::Error;
 
 fn hex_scalar(input: State<&str>) -> ParseResult<String, &str> {
     satisfy(|c| c == 'x' || c == 'X')
@@ -401,6 +402,13 @@ pub fn expr(input: State<&str>) -> ParseResult<ExprNode, &str> {
                     .or(try(parser(string_const).map(StringConst)))
                 )
             ).parse_state(input)
+}
+
+pub fn parse(program: &str) -> Result<ExprNode, String> {
+    parser(expr) // todo: this should build a root node instead
+        .parse(program)
+        .map_err(|e| { let mut s = String::new(); s.push_str(e.description()); s} )
+        .map(    |x| x.0 )
 }
 
 #[cfg(test)]

--- a/seax_scheme/src/parser/mod.rs
+++ b/seax_scheme/src/parser/mod.rs
@@ -11,6 +11,7 @@ use std::num::FromStrRadix;
 use std::char;
 use std::error::Error;
 
+#[stable(feature="parser",since="0.0.2")]
 fn hex_scalar(input: State<&str>) -> ParseResult<String, &str> {
     satisfy(|c| c == 'x' || c == 'X')
         .with( many1(hex_digit()) )
@@ -24,6 +25,7 @@ fn hex_scalar(input: State<&str>) -> ParseResult<String, &str> {
 /// TODO: add support for octal
 /// TODO: add support for binary
 /// TODO: add support for R6RS exponents
+#[unstable(feature="parser")]
 pub fn sint_const(input: State<&str>) -> ParseResult<NumNode, &str> {
 
     fn hex_isize(input: State<&str>) -> ParseResult<isize, &str> {
@@ -71,6 +73,7 @@ pub fn sint_const(input: State<&str>) -> ParseResult<NumNode, &str> {
 /// TODO: add support for octal
 /// TODO: add support for binary
 /// TODO: add support for R6RS exponents
+#[unstable(feature="parser")]
 pub fn uint_const(input: State<&str>) -> ParseResult<NumNode, &str> {
 
     fn hex_uint(input: State<&str>) -> ParseResult<usize, &str> {
@@ -97,6 +100,7 @@ pub fn uint_const(input: State<&str>) -> ParseResult<NumNode, &str> {
 /// i.e. `1F`, are currently not recognized. While this form of number
 /// is not specified by R6RS, I'd like to support it anyway as it's
 /// a common form for floating-point numbers. Priority: low.
+#[stable(feature="parser",since="0.0.2")]
 pub fn float_const(input: State<&str>) -> ParseResult<NumNode, &str> {
     many1::<String,_>(digit())
         .and(satisfy(|c| c == '.'))
@@ -125,6 +129,7 @@ pub fn float_const(input: State<&str>) -> ParseResult<NumNode, &str> {
 ///
 /// `#t`, `#T`, or `true`  -> `true`
 /// `#f`, `#F`, or `false` -> `false`
+#[stable(feature="parser",since="0.0.2")]
 pub fn bool_const(input: State<&str>) -> ParseResult<BoolNode, &str> {
 
     let t_const = try(string("#t"))
@@ -141,6 +146,7 @@ pub fn bool_const(input: State<&str>) -> ParseResult<BoolNode, &str> {
 }
 
 /// Parses a floating-point, signed integer, or unsigned integer constant.
+#[stable(feature="parser",since="0.0.2")]
 pub fn number(input: State<&str>) -> ParseResult<NumNode, &str> {
     try(parser(sint_const))
         .or(try(parser(uint_const)))
@@ -160,6 +166,7 @@ pub fn number(input: State<&str>) -> ParseResult<NumNode, &str> {
 ///
 /// For more information, consult the
 /// [R6RS](http://www.r6rs.org/final/html/r6rs/r6rs-Z-H-7.html).
+#[stable(feature="parser",since="0.0.2")]
 pub fn name(input: State<&str>) -> ParseResult<NameNode, &str> {
 
     fn initial(input: State<&str>) -> ParseResult<char, &str> {
@@ -220,6 +227,7 @@ pub fn name(input: State<&str>) -> ParseResult<NameNode, &str> {
 /// 3. Hex scalar value
 ///     + delimited with the character `x`
 ///     + e.g. `#\x1B` etc.
+#[stable(feature="parser",since="0.0.2")]
 pub fn character(input: State<&str>) -> ParseResult<CharNode, &str> {
 
     fn newline(input: State<&str>) -> ParseResult<char, &str> {
@@ -319,12 +327,13 @@ pub fn character(input: State<&str>) -> ParseResult<CharNode, &str> {
 }
 
 /// Parses a R<sup>6</sup>RS single-line comment
+#[unstable(feature="parser")]
 pub fn line_comment(input: State<&str>) -> ParseResult<(),&str> {
     satisfy(|c| c == ';')
         .with(skip_many(satisfy(|c| c != '\n')).skip(newline()))
         .parse_state(input)
 }
-
+#[stable(feature="parser",since="0.0.2")]
 pub fn string_const(input: State<&str>) -> ParseResult<StringNode, &str> {
 
     fn escape_char(input: State<&str>) -> ParseResult<char, &str> {
@@ -362,6 +371,7 @@ pub fn string_const(input: State<&str>) -> ParseResult<StringNode, &str> {
 
 /// Parses Scheme expressions.
 #[allow(unconditional_recursion)]
+#[stable(feature="parser",since="0.0.2")]
 pub fn expr(input: State<&str>) -> ParseResult<ExprNode, &str> {
 
         fn sexpr(input: State<&str>) -> ParseResult<ExprNode, &str> {
@@ -403,7 +413,7 @@ pub fn expr(input: State<&str>) -> ParseResult<ExprNode, &str> {
                 )
             ).parse_state(input)
 }
-
+#[unstable(feature="parser")]
 pub fn parse(program: &str) -> Result<ExprNode, String> {
     parser(expr) // todo: this should build a root node instead
         .parse(program)

--- a/seax_scheme/src/parser/mod.rs
+++ b/seax_scheme/src/parser/mod.rs
@@ -7,7 +7,6 @@ use super::ast::*;
 use super::ast::ExprNode::*;
 
 use std::str::FromStr;
-use std::num::FromStrRadix;
 use std::char;
 use std::error::Error;
 


### PR DESCRIPTION
I've done some additional work on Scheme, including adding tests and feature-gating the public API. This isn't deserving of a new Scheme version, but I'd like to add it to the v0.0.3 snapshot. Since that snapshot hasn't been published yet ([I blame Travis for this](https://travis-ci.org/hawkw/seax/builds/57416954#L2906)) I'm gong to go ahead and merge this into master, push the tag `scheme-v0.0.3-rc.2`, and publish.
