### PR TITLE
Compilation for `let` bindings

### DIFF
--- a/seax_scheme/src/ast/mod.rs
+++ b/seax_scheme/src/ast/mod.rs
@@ -279,11 +279,15 @@ impl ASTNode for SExprNode {
                                 operator: box Name(ref node),
                                 operands: ref param_body
                             } => {
+
                                 sym.bind(node.name.as_ref(),depth);
+
                                 for exp in param_body {
                                     result.push_all(&try!(exp.compile(&sym)));
                                 }
+
                                 result.push(InstCell(CONS));
+
                                 Ok(result)
                             },
                             _ => Err("[error]: malformed let expression".to_string())
@@ -293,22 +297,28 @@ impl ASTNode for SExprNode {
                                     operator: box Name(ref node),
                                     operands: ref param_body
                                 }) = param_b {
+
                                     sym.bind(node.name.as_ref(),depth);
+
                                     for ref exp in param_body {
                                         result.push_all(&try!(exp.compile(&sym)));
                                     }
+
                                     result.push(InstCell(CONS));
                                 }
                             }
                             Ok(result)
                         }).and_then(|mut result: Vec<SVMCell> | {
-                            result.push(InstCell(LDF));
 
                             let mut body_code = Vec::new();
                             body_code.push_all(&try!(body_exp.compile(&sym)));
                             body_code.push(InstCell(RET));
 
-                            result.push(ListCell(box List::from_iter(body_code)));
+                            result.push_all(&[
+                                InstCell(LDF),
+                                ListCell(box List::from_iter(body_code)),
+                                InstCell(AP)
+                            ]);
 
                             Ok(result)
 

--- a/seax_scheme/src/ast/mod.rs
+++ b/seax_scheme/src/ast/mod.rs
@@ -266,7 +266,7 @@ impl ASTNode for SExprNode {
                 "let" => match self.operands.as_slice() {
                     [SExpr(SExprNode{
                         operator: box SExpr(ref param_a),
-                        operands: ref param_bs}), SExpr(ref body_exp)] => {
+                        operands: ref param_bs}), ref body_exp] => {
 
                         let mut sym = state.fork();
                         let mut result = Vec::new();
@@ -314,7 +314,7 @@ impl ASTNode for SExprNode {
 
                         })
                     },
-                    _ => Err("[error]: malformed let expression".to_string())
+                    _ => Err(format!("[error]: malformed let expression:\n{:?}",self))
                 },
                 _ => { // TODO: this is basically a duplicate of the general case
                        // I feel bad for doing it this way but nothing else worked
@@ -570,7 +570,7 @@ impl ASTNode for NameNode {
         result.push_str(tab.as_ref());
         result.push_str("Name: ");
         result.push_str(self.name.as_ref());
-        result.push_str("\n");
+        result.push('\n');
 
         result
     }
@@ -615,15 +615,15 @@ impl ASTNode for NumNode {
         match *self {
             NumNode::UIntConst(ref node) => {
                 result.push_str(format!("{}u", node.value).as_ref());
-                result.push_str("\n");
+                result.push('\n');
             },
             NumNode::IntConst(ref node) => {
                 result.push_str(format!("{}", node.value).as_ref());
-                result.push_str("\n");
+                result.push('\n');
             },
             NumNode::FloatConst(ref node) => {
                 result.push_str(format!("{}f", node.value).as_ref());
-                result.push_str("\n");
+                result.push('\n');
             }
         }
         result
@@ -674,7 +674,7 @@ impl ASTNode for BoolNode {
         result.push_str(tab.as_ref());
         result.push_str("Boolean: ");
         result.push_str(format!("{}", self.value).as_ref());
-        result.push_str("\n");
+        result.push('\n');
         result
     }
 }

--- a/seax_scheme/tests/lib.rs
+++ b/seax_scheme/tests/lib.rs
@@ -353,3 +353,41 @@ fn compile_expr_let() {
         ))
     );
 }
+
+/// Test for the compilation of a `let` binding with name shadowing
+///
+/// ```lisp
+/// (let ([x 1])
+///     (let ([x 2]) x)
+///     )
+/// ```
+#[test]
+fn compile_name_shadowing_let() {
+    assert_eq!(
+        scheme::compile("(let ([x 1])
+                            (let ([x 2]) x))"),
+        Ok(list!(
+            InstCell(NIL),
+            InstCell(LDC), AtomCell(SInt(1)),
+            InstCell(CONS),
+            InstCell(LDF),
+            ListCell(box list!(
+                InstCell(NIL),
+                InstCell(LDC), AtomCell(SInt(2)),
+                InstCell(CONS),
+                InstCell(LDF),
+                ListCell(box list!(
+                    InstCell(LD), ListCell(box list!(
+                            AtomCell(UInt(1)),AtomCell(UInt(1))
+                        )),
+                InstCell(RET)
+                )),
+            InstCell(AP),
+            InstCell(RET)
+            )),
+            InstCell(AP)
+        ))
+    );
+}
+
+

--- a/seax_scheme/tests/lib.rs
+++ b/seax_scheme/tests/lib.rs
@@ -325,3 +325,31 @@ fn compile_multiple_let() {
         ))
     );
 }
+
+/// Test for the compilation of a `let` binding to the result of
+/// an expression.
+///
+/// ```lisp
+/// (let ([x (+ 1 1)]) x
+/// ```
+#[test]
+fn compile_expr_let() {
+    assert_eq!(
+        scheme::compile("(let ([x (+ 1 1)]) x)"),
+        Ok(list!(
+            InstCell(NIL),
+            InstCell(LDC), AtomCell(SInt(1)),
+            InstCell(LDC), AtomCell(SInt(1)),
+            InstCell(ADD),
+            InstCell(CONS),
+            InstCell(LDF),
+            ListCell(box list!(
+                InstCell(LD), ListCell(box list!(
+                        AtomCell(UInt(1)),AtomCell(UInt(1))
+                    )),
+                InstCell(RET)
+            )),
+            InstCell(AP)
+        ))
+    );
+}

--- a/seax_scheme/tests/lib.rs
+++ b/seax_scheme/tests/lib.rs
@@ -259,3 +259,27 @@ fn compile_nested_lambda() {
         ))
     )
 }
+
+/// Test for the compilation of a single simple `let` binding.
+///
+/// ```lisp
+/// (let ([x 5]) x)
+/// ```
+#[test]
+fn compile_single_let() {
+    assert_eq!(
+        scheme::compile("(let ([x 5]) x)"),
+        Ok(list!(
+            InstCell(NIL),
+            InstCell(LDC), AtomCell(SInt(5)), InstCell(CONS),
+            InstCell(LDF),
+            ListCell(box list!(
+                InstCell(LD), ListCell(box list!(
+                        AtomCell(UInt(1)),AtomCell(UInt(1))
+                    )),
+                InstCell(RET)
+            )),
+            InstCell(AP)
+        ))
+    );
+}

--- a/seax_scheme/tests/lib.rs
+++ b/seax_scheme/tests/lib.rs
@@ -283,3 +283,45 @@ fn compile_single_let() {
         ))
     );
 }
+
+
+/// Test for the compilation of multiple simple `let` bindings.
+///
+/// ```lisp
+/// (let ([x 1]
+///       [y 2]
+///       [z 3])
+///      (+ x y z))
+/// ```
+#[test]
+fn compile_multiple_let() {
+    assert_eq!(
+        scheme::compile(
+            "(let ([x 1]
+                   [y 2]
+                   [z 3])
+                (+ x y z))"),
+        Ok(list!(
+            InstCell(NIL),
+            InstCell(LDC), AtomCell(SInt(1)), InstCell(CONS),
+            InstCell(LDC), AtomCell(SInt(2)), InstCell(CONS),
+            InstCell(LDC), AtomCell(SInt(3)), InstCell(CONS),
+            InstCell(LDF),
+            ListCell(box list!(
+                InstCell(LD), ListCell(box list!(
+                        AtomCell(UInt(1)),AtomCell(UInt(3))
+                    )),
+                InstCell(LD), ListCell(box list!(
+                        AtomCell(UInt(1)),AtomCell(UInt(2))
+                    )),
+                InstCell(ADD),
+                InstCell(LD), ListCell(box list!(
+                        AtomCell(UInt(1)),AtomCell(UInt(1))
+                    )),
+                InstCell(ADD),
+                InstCell(RET)
+            )),
+            InstCell(AP)
+        ))
+    );
+}


### PR DESCRIPTION
`let` bindings are compiled correctly as of fbc18fbc7ae17dd5b563391fe01192a33ba04e2a. This closes #54 and should release Seax Scheme v0.2.0.
