### PR TITLE
Update to build successfully on latest nightly.

### DIFF
--- a/seax_scheme/src/lib.rs
+++ b/seax_scheme/src/lib.rs
@@ -3,6 +3,7 @@
 #![crate_type = "lib"]
 #![feature(convert)]
 #![feature(box_syntax,box_patterns)]
+#![feature(vec_push_all)]
 #![feature(slice_patterns)]
 #![feature(collections)]
 #![feature(staged_api)]


### PR DESCRIPTION
Apparently some genius thought that Vec::push_all() deserved to be feature-gated for reasons that I will probably never understand. Great. Thanks a lot.
